### PR TITLE
Microservice-INCIDENT : Ajout de la fonction assign_incident()

### DIFF
--- a/incident/src/main.py
+++ b/incident/src/main.py
@@ -95,6 +95,23 @@ def get_incident_by_id(incident_id):
     return jsonify(incident), 200
 
 
+@app.route("/api/v1/incidents/<incident_id>/assign", methods=["POST"])
+def assign_incident(incident_id):
+    incident = db["incidents"].get(incident_id)
+    if not incident:
+        return jsonify({"error": "Incident not found"}), 404
+
+    data = request.get_json() or {}
+    commander = data.get("commander")
+    if not commander:
+        return jsonify({"error": "Missing field 'commander'"}), 400
+
+    incident["commander"] = commander
+    db["incidents"][incident_id] = incident  # update local store
+
+    return jsonify(incident), 200
+
+
 # Lancement du serveur
 if __name__ == '__main__':
     # On récupère le port depuis les variables d'environnement, avec 5000 comme valeur par défaut.

--- a/incident/tests/test_main.py
+++ b/incident/tests/test_main.py
@@ -152,7 +152,8 @@ def test_assign_incident(client):
         "title": "Database outage",
         "sev": 2,
         "services": ["db"],
-        "summary": "Primary DB unavailable"
+        "summary": "Primary DB unavailable",
+        "commander": "thomas"
     }
     create_response = client.post("/api/v1/incidents", json=payload)
     created = create_response.get_json()


### PR DESCRIPTION
# PR : Ajout de la route POST /api/v1/incidents/\<id\>/assign

## Contexte
Cette PR introduit la route permettant d’assigner un incident à un utilisateur (ou SRE).  
Elle s’appuie sur le stockage temporaire en dictionnaire local (db) avant l’intégration avec Redis.

## Nouveauté
_Route_ : **POST /api/v1/incidents/\<id\>/assign**  
- Objectif : Attribuer un champ `commander` à un incident existant.  
- Fichier : src/main.py  
- Test associé : test_assign_incident dans tests/test_main.py  

_Exemple d’appel :_
```bash
curl -X POST http://127.0.0.1:5000/api/v1/incidents/INC-12345/assign \
    -H "Content-Type: application/json" \
    -d '{"commander": "user-1"}'
```
_Exemple de réponse :_
```json
{
  "id": "INC-12345",
  "title": "API Latency EU",
  "sev": 3,
  "status": "open",
  "services": ["api"],
  "summary": "High latency detected in EU-West",
  "commander": "user-1"
}
```
## Réponses possibles		

| Code	  | Signification	| Détail |
| :---------------:|:---------------:|:-----:|
| 200 | Succès	                |  Incident mis à jour avec un commander |
| 400 | Mauvaise requête |  Corps JSON manquant ou invalide         |
| 404 | Introuvable	        |  Aucun incident avec cet ID                      |

## Tests
Un test unitaire a été ajouté dans tests/test_main.py :
- test_assign_incident

## Exécution
```bash
pytest -v
```

## Détails techniques
- Lecture du corps JSON via `request.get_json()`.
- Vérification de la présence du champ `commander`.
- Mise à jour de l’incident dans le dictionnaire local.
- Retourne **404** si l’incident n’existe pas.

## Checklist avant merge
- Code testé et fonctionnel
- Route conforme au Swagger
- Aucune régression sur les routes existantes
- Documentation mise à jour

## Relecteurs
@augustinprotin @elBaptiste @Mpucheu2 @a-mth @TDEVYS @Fabaure