### PR TITLE
Ajoute la page de création d'incident (/admin/incidents/new)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,11 +19,13 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
+        "next-themes": "^0.4.6",
         "react": "^19.1.1",
         "react-auth-kit": "^4.0.2-alpha.11",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.66.0",
         "react-router": "^7.9.5",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.16",
         "zod": "^4.1.12"
@@ -4916,6 +4918,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -5633,6 +5645,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,11 +25,13 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
+    "next-themes": "^0.4.6",
     "react": "^19.1.1",
     "react-auth-kit": "^4.0.2-alpha.11",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.66.0",
     "react-router": "^7.9.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.16",
     "zod": "^4.1.12"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ProfilePage from '@/routes/ProfilePage.tsx';
 import DashboardPage from '@/routes/DashboardPage';
 import IncidentsPage from '@/routes/IncidentsPage';
 import IncidentCreatePage from '@/routes/IncidentCreatePage.tsx';
+import { Toaster } from '@/components/ui/sonner.tsx';
 
 export default function App() {
     return (
@@ -31,11 +32,13 @@ export default function App() {
                     <Route path="/forgot-password" element={<ForgotPasswordPage />} />
                     <Route path="/reset-password" element={<ResetPasswordPage />} />
                     <Route path="/dashboard" element={(<ProtectedRoute><DashboardPage /></ProtectedRoute>)} />
-                    <Route path="/admin/incidents/new" element={<IncidentCreatePage/>}/>
+                    <Route path="/admin/incidents/new"
+                           element={(<ProtectedRoute><IncidentCreatePage /></ProtectedRoute>)} />
                     {/* catch-all for unknown routes */}
                     <Route path="*" element={<NotFound />} />
                 </Routes>
             </main>
+            <Toaster />
         </div>
     );
 }

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/src/lib/setup-tests.ts
+++ b/frontend/src/lib/setup-tests.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+
+if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: (query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            dispatchEvent: () => false,
+        }),
+    });
+}

--- a/frontend/src/routes/DashboardPage.test.tsx
+++ b/frontend/src/routes/DashboardPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import DashboardPage from './DashboardPage';
 import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
 
 vi.mock('react-auth-kit/hooks/useAuthUser', () => ({
     default: () => ({
@@ -28,7 +29,11 @@ vi.mock('../mocks/mockData', () => ({
     ],
 }));
 test('doit afficher le résumé des incidents critiques (2)', () => {
-    render(<DashboardPage />);
+    render(
+        <MemoryRouter>
+            <DashboardPage />
+        </MemoryRouter>,
+    );
     const summaryLabel = screen.getByText(/Incidents Critiques en Cours/i);
     const summaryContainer = summaryLabel.closest('div');
     expect(summaryContainer).not.toBeNull();
@@ -36,7 +41,11 @@ test('doit afficher le résumé des incidents critiques (2)', () => {
     expect(summaryCount).toBeInTheDocument();
 });
 test('doit afficher uniquement les incidents assignés à l\'utilisateur (2)', () => {
-    render(<DashboardPage />);
+    render(
+        <MemoryRouter>
+            <DashboardPage />
+        </MemoryRouter>,
+    );
     const assignedIncident1 = screen.getByText(/Serveur critique/i);
     const assignedIncident2 = screen.getByText(/Bug majeur/i);
     const unassignedIncident = screen.queryByText(/Fichier critique/i);

--- a/frontend/src/routes/DashboardPage.tsx
+++ b/frontend/src/routes/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { type MockIncident, mockIncidents } from '@/mocks/mockData';
 import type { AuthUser } from '@/auth/types.ts';
 import useAuthUser from 'react-auth-kit/hooks/useAuthUser';
+import { Link } from 'react-router';
 
 function DashboardPage() {
     const user = useAuthUser<AuthUser | null>();
@@ -26,9 +27,17 @@ function DashboardPage() {
         // Conteneur centré
         <div className="p-10 max-w-6xl mx-auto space-y-10 min-h-screen">
 
-            <h1 className="text-4xl font-extrabold text-gray-800 border-b pb-4">
-                Tableau de Bord SRE
-            </h1>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <h1 className="text-4xl font-extrabold text-gray-800 border-b pb-4">
+                    Tableau de Bord SRE
+                </h1>
+                <Link
+                    to="/admin/incidents/new"
+                    className="inline-flex items-center justify-center rounded-md border border-blue-600 bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                    Signaler un incident
+                </Link>
+            </div>
             {/* Résumé des Critiques (Simule un composant Stat Card) */}
             <div className="p-6 rounded-xl shadow-2xl bg-white border-l-8 border-red-600">
                 <p className="text-lg text-gray-500">Incidents Critiques en Cours</p>

--- a/frontend/src/routes/IncidentCreatePage.test.tsx
+++ b/frontend/src/routes/IncidentCreatePage.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import IncidentCreatePage from './IncidentCreatePage';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { expect, test, vi } from 'vitest';
 
 const renderPage = () => {
     render(
         <BrowserRouter>
-        <IncidentCreatePage />
-        </BrowserRouter>
+            <IncidentCreatePage />
+        </BrowserRouter>,
     );
 
     return {
@@ -19,8 +19,10 @@ const renderPage = () => {
 test('doit afficher les champs du formulaire de création', () => {
     renderPage();
     const titleInput = screen.getByLabelText(/Titre de l'incident/i);
+    const severitySelect = screen.getByLabelText(/Sévérité/i);
     const submitButton = screen.getByRole('button', { name: /Signaler l'incident/i });
     expect(titleInput).toBeInTheDocument();
+    expect(severitySelect).toBeInTheDocument();
     expect(submitButton).toBeInTheDocument();
 });
 
@@ -28,21 +30,23 @@ test('doit appeler l\'API POST /api/incidents lors de la soumission', async () =
     const fetchSpy = vi.spyOn(window, 'fetch');
     const { user } = renderPage();
     const titleInput = screen.getByLabelText(/Titre de l'incident/i);
+    const severitySelect = screen.getByLabelText(/Sévérité/i);
     const submitButton = screen.getByRole('button', { name: /Signaler l'incident/i });
     await user.type(titleInput, 'Panne majeure du serveur de login');
+    await user.selectOptions(severitySelect, '1');
     await user.click(submitButton);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith(
         'http://localhost:8081/api/incidents',
         expect.objectContaining({
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-            title: 'Panne majeure du serveur de login',
-            sev: 2
-        })
-        })
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                title: 'Panne majeure du serveur de login',
+                sev: 1,
+            }),
+        }),
     );
 });

--- a/frontend/src/routes/IncidentCreatePage.tsx
+++ b/frontend/src/routes/IncidentCreatePage.tsx
@@ -1,27 +1,40 @@
 import React, { useState } from 'react';
+import { toast } from 'sonner';
+
+const severityOptions = [
+    { value: 1, label: 'Critique' },
+    { value: 2, label: 'Majeure' },
+    { value: 3, label: 'Mineure' },
+];
 
 function IncidentCreatePage() {
     const [title, setTitle] = useState('');
-    const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    const incidentData = {
-        title: title,
-      sev: 2 
-    };
-    try {
-        await fetch('http://localhost:8081/api/incidents', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(incidentData)
-        });
-        console.log('Incident signalé avec succès !');
-        setTitle('');
+    const [severity, setSeverity] = useState(2);
 
-    } catch (error) {
-        console.error("Erreur lors de la soumission de l'incident:", error);
-    }
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const incidentData = {
+            title,
+            sev: severity,
+        };
+
+        try {
+            await fetch('http://localhost:8081/api/incidents', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(incidentData),
+            });
+
+            toast.success('Incident signalé avec succès !');
+            setTitle('');
+            setSeverity(2);
+        } catch (error) {
+            console.error("Erreur lors de la soumission de l'incident:", error);
+            toast.error('Impossible de signaler l’incident pour le moment.');
+        }
     };
 
     return (
@@ -50,6 +63,27 @@ function IncidentCreatePage() {
                     value={title}
                     onChange={(e) => setTitle(e.target.value)}
                 />
+            </div>
+
+            <div>
+                <label
+                    htmlFor="severity"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                    Sévérité
+                </label>
+                <select
+                    id="severity"
+                    className="mt-1 block w-full rounded-md border border-gray-300 bg-white py-2 px-3 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:text-sm"
+                    value={severity}
+                    onChange={(e) => setSeverity(Number(e.target.value))}
+                >
+                    {severityOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
             </div>
 
             <div className="pt-4">


### PR DESCRIPTION
Salut l'équipe,
Voici la Pull Request pour la nouvelle page "Signaler un nouvel incident" (/admin/incidents/new).
La fonctionnalité est complète et a été développée en suivant rigoureusement le cycle TDD :
Cycle 1 : Affichage
RED  : Test pour l'affichage des champs (label "Titre", bouton "Signaler").
GREEN  : Ajout du formulaire de base stylisé (Tailwind) et de la route dans App.tsx.
Cycle 2 : Soumission (GREEN )
RED  : Test pour la soumission du formulaire, simulant un user.click et en espionnant window.fetch.
GREEN  : Implémentation de useState et handleSubmit pour appeler l'API POST /api/incidents (conformément au Swagger de l'équipe Incidents).
La page est prête pour la revue de code !